### PR TITLE
Fix few restore issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 [![Donate via PayPal](https://img.shields.io/badge/Donate-PayPal-blue.svg?style=flat-square)](https://www.paypal.me/techtoday) 
 
 <p>
+<b>Version 1.0.32</b> September 2021<br/>
+- Fix few restore issues. Line-in restore fix and only when it was playing. Amazon Music and Spotify considered as stream instead of music queue.<br/>
+<p>
+<p>
 <b>Version 1.0.31</b> September 2021<br/>
 - NEW: you can now choose voice PITCH and RATE. Avaiable only with Google TTS engine with credentials.<br/>
 <p>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-red-contrib-tts-ultimate",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "description": "Transforms the text in speech and hear it using Sonos player. Works with voices from Amazon, Google (without credentials as well) or your own voice. Update of the popular SonosPollyTTS node.",
   "main": "index.js",
   "scripts": {

--- a/ttsultimate/ttsultimate.js
+++ b/ttsultimate/ttsultimate.js
@@ -399,7 +399,8 @@ module.exports = function (RED) {
 
             if (_oTrack !== null) {
                 // Do some checks on the track.
-                if (_oTrack.hasOwnProperty("duration") && _oTrack.duration === 0 || _oTrack.uri.startsWith("x-sonosprog-http")) {
+                if (_oTrack.hasOwnProperty("duration") && _oTrack.duration === 0 || 
+                      (_oTrack.uri.startsWith("x-sonosprog-http") || _oTrack.uri.startsWith("x-sonosapi-hls-static") || _oTrack.uri.startsWith("x-sonos-spotify"))) {
                     // Stream
                     _oTrack.trackType = "stream";
                 } else if (_oTrack.hasOwnProperty("duration") && isNaN(_oTrack.duration)) {
@@ -463,10 +464,12 @@ module.exports = function (RED) {
                     }
                 } else if (_oTrack.trackType === "lineinput") {
                     // Line in, TV in, etc...
-                    try {
-                        await setAVTransportURISync(_oTrack.uri);
-                    } catch (error) {
-                        return error;
+                    if (_oTrack.state === "playing") {
+                        try {
+                            await setAVTransportURISync(_oTrack.uri);
+                        } catch (error) {
+                            return error;
+                        }
                     }
                 }
             }
@@ -711,7 +714,7 @@ module.exports = function (RED) {
 
                     // Resume music
                     try {
-                        if (oCurTrack !== null && oCurTrack.title.indexOf(".mp3") === -1) {
+                        if (oCurTrack !== null && (!oCurTrack.hasOwnProperty("title") || oCurTrack.title.indexOf(".mp3") === -1)) {
                             node.setNodeStatus({ fill: 'grey', shape: 'ring', text: "Resuming original queue..." });
                             await resumeMusicQueue(oCurTrack);
                             node.setNodeStatus({ fill: 'green', shape: 'ring', text: "Done resuming queue." });


### PR DESCRIPTION
- Line-in restore was not working as it throw an exemption because `oCurTrack.title` was undefined
- Line-in restored only when current state was "playing" (it was restoring it even when paused)  
- Amazon Music was considered a "musicqueue" instead of "stream" which causes the restoration to play the next track in the queue instead of continue playing Amazon. Note this is still not ideal as only the current Amazon track would be played and nothing else. Looks there is no way to continue playing from Amazon that I know. I also added the Spotify url which is probably in the same issue, but do not have Spotify to validate it.
 